### PR TITLE
Split workflows on push and pull request

### DIFF
--- a/.github/workflows/ci_with_osx_on_pull_request.yml
+++ b/.github/workflows/ci_with_osx_on_pull_request.yml
@@ -1,6 +1,6 @@
-name: Continuous Integration - OSX
+name: Continuous Integration on Pull Request - OSX
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   tests:

--- a/.github/workflows/ci_with_osx_on_push_to_main.yml
+++ b/.github/workflows/ci_with_osx_on_push_to_main.yml
@@ -1,10 +1,15 @@
-name: Continuous Integration - Windows
+name: Continuous Integration - OSX
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - main
+
 
 jobs:
   tests:
-    runs-on: windows-latest
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci_with_ubuntu_on_pull_request.yml
+++ b/.github/workflows/ci_with_ubuntu_on_pull_request.yml
@@ -1,0 +1,47 @@
+name: Continuous Integration on Pull Request - Ubuntu
+
+on: [pull_request]
+
+jobs:
+  Execute:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.x
+
+    - name: Install Dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        pip3 install --upgrade coveralls
+        pip3 install .[dev]
+
+    - name: Check
+      run: |
+        python precommit.py
+
+    - name: Upload Coverage
+      run: coveralls --service=github
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
+        COVERALLS_PARALLEL: true
+
+  Finish-Coveralls:
+    name: Finish Coveralls
+    needs: Execute
+    runs-on: ubuntu-latest
+    container: python:3-slim
+    steps:
+      - name: Finish Coveralls
+        run: |
+          pip3 install --upgrade coveralls
+          coveralls --finish --service=github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_with_ubuntu_on_push_to_main.yml
+++ b/.github/workflows/ci_with_ubuntu_on_push_to_main.yml
@@ -1,6 +1,10 @@
 name: Continuous Integration - Ubuntu
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - main
 
 jobs:
   Execute:

--- a/.github/workflows/ci_with_windows_on_pull_request.yml
+++ b/.github/workflows/ci_with_windows_on_pull_request.yml
@@ -1,0 +1,22 @@
+name: Continuous Integration on Pull Request - Windows
+
+on: [pull_request]
+
+jobs:
+  tests:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.x
+
+    - name: Install Dependencies
+      run: |
+        pip3 install .[dev]
+
+    - name: Check
+      run: |
+        python precommit.py

--- a/.github/workflows/ci_with_windows_on_push_to_main.yml
+++ b/.github/workflows/ci_with_windows_on_push_to_main.yml
@@ -1,0 +1,26 @@
+name: Continuous Integration - Windows
+
+on:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  tests:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.x
+
+    - name: Install Dependencies
+      run: |
+        pip3 install .[dev]
+
+    - name: Check
+      run: |
+        python precommit.py


### PR DESCRIPTION
This patch duplicates the workflows so that they do not run in double
for no reason. This saves some CO2 in the atmosphere.